### PR TITLE
Feat/load pretrained

### DIFF
--- a/base_trainer.py
+++ b/base_trainer.py
@@ -76,6 +76,7 @@ SCHEDULER_NAME = "scheduler.pt"
 SCALER_NAME = "scaler.pt"
 
 import wandb
+import os
 from datasets import load_dataset
 class EvalCallback(TrainerCallback):
     def __init__(self):
@@ -179,6 +180,13 @@ class BaseTrainer(Trainer):
             return out
 
     def _save(self, output_dir: Optional[str] = None, state_dict=None):
+
+        if wandb.run is not None:
+            output_dir_ = output_dir if output_dir is not None else self.args.output_dir
+            os.makedirs(output_dir_, exist_ok=True)
+            run_id = wandb.run.id
+            with open(os.path.join(output_dir_, "wandb_id"), "w") as f:
+                f.write(run_id)
         if not self.args_to_save.train_embed_only or not self.saved_full_model:
             super()._save(output_dir, state_dict)
         else:

--- a/config_parser.py
+++ b/config_parser.py
@@ -37,7 +37,7 @@ def parse_config(config_path):
     #     run_name_suffix += "_check"
     if config["train_embed_only"]:
         run_name_suffix += "_embed_only"
-    run_name_suffix += "_test"
+    # run_name_suffix += "_test"
 
     # run_name=f"{config['base_model']}_config['run_name_suffix']"
     config["run_name"] = f"{config['run_name']}_{run_name_suffix}"

--- a/config_parser.py
+++ b/config_parser.py
@@ -38,7 +38,7 @@ def parse_config(config_path):
     #     run_name_suffix += "_check"
     if config["train_embed_only"]:
         run_name_suffix += "_embed_only"
-    # run_name_suffix += "_test"
+    run_name_suffix += "_test"
 
     # run_name=f"{config['base_model']}_config['run_name_suffix']"
     config["run_name"] = f"{config['run_name']}_{run_name_suffix}"
@@ -53,6 +53,7 @@ def parse_config(config_path):
     keys_to_remove = [
         "base_model",
         "checkpointing",
+        "resume_run",
         "dir",
         "eval_domains",
         "node",
@@ -65,10 +66,11 @@ def parse_config(config_path):
         "train_domains",
     ]
 
+    config_run = config.copy()
     config = {k: v for k, v in config.items() if k not in keys_to_remove}
     parser = HfArgumentParser(
         (ModelArguments, DataTrainingArguments, TrainingArguments)
     )
     model_args_dict, data_args_dict, training_args_dict = parser.parse_dict(config)
 
-    return model_args_dict, data_args_dict, training_args_dict
+    return model_args_dict, data_args_dict, training_args_dict, config_run

--- a/config_parser.py
+++ b/config_parser.py
@@ -37,7 +37,7 @@ def parse_config(config_path):
     #     run_name_suffix += "_check"
     if config["train_embed_only"]:
         run_name_suffix += "_embed_only"
-    # run_name_suffix += "_test"
+    run_name_suffix += "_test"
 
     # run_name=f"{config['base_model']}_config['run_name_suffix']"
     config["run_name"] = f"{config['run_name']}_{run_name_suffix}"

--- a/configs/accelerate_2gpu.yaml
+++ b/configs/accelerate_2gpu.yaml
@@ -2,7 +2,7 @@ compute_environment: LOCAL_MACHINE
 debug: false
 distributed_type: MULTI_GPU
 downcast_bf16: 'no'
-gpu_ids: "0,2"
+gpu_ids: "0,1"
 machine_rank: 0
 main_training_function: main
 mixed_precision: bf16

--- a/configs/accelerate_3gpu.yaml
+++ b/configs/accelerate_3gpu.yaml
@@ -2,12 +2,12 @@ compute_environment: LOCAL_MACHINE
 debug: false
 distributed_type: MULTI_GPU
 downcast_bf16: 'no'
-gpu_ids: "0,2"
+gpu_ids: "0,2,4"
 machine_rank: 0
 main_training_function: main
 mixed_precision: bf16
 num_machines: 1
-num_processes: 2
+num_processes: 3
 rdzv_backend: static
 same_network: true
 tpu_env: []

--- a/configs/accelerate_3gpu.yaml
+++ b/configs/accelerate_3gpu.yaml
@@ -2,7 +2,7 @@ compute_environment: LOCAL_MACHINE
 debug: false
 distributed_type: MULTI_GPU
 downcast_bf16: 'no'
-gpu_ids: "0,2,4"
+gpu_ids: "0,1,2"
 machine_rank: 0
 main_training_function: main
 mixed_precision: bf16

--- a/configs/accelerate_3gpu.yaml
+++ b/configs/accelerate_3gpu.yaml
@@ -2,7 +2,7 @@ compute_environment: LOCAL_MACHINE
 debug: false
 distributed_type: MULTI_GPU
 downcast_bf16: 'no'
-gpu_ids: "0,1,2"
+gpu_ids: "1,2,3"
 machine_rank: 0
 main_training_function: main
 mixed_precision: bf16

--- a/configs/accelerate_4gpu.yaml
+++ b/configs/accelerate_4gpu.yaml
@@ -2,7 +2,7 @@ compute_environment: LOCAL_MACHINE
 debug: false
 distributed_type: MULTI_GPU
 downcast_bf16: 'no'
-gpu_ids: "3,5,6,7"
+gpu_ids: "0,1,2,3"
 machine_rank: 0
 main_training_function: main
 mixed_precision: bf16

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -11,8 +11,6 @@ defaults:
   logging_steps: 1
   add_special_tokens: false
   use_fast_tokenizer: false
-  num_gpus: 2
-  num_nodes: 1
   node: "localhost"
   accumulate_summary: true
   remove_unused_columns: false

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -6,7 +6,7 @@ defaults:
   per_device_eval_batch_size: 2
   per_device_train_batch_size: 2
   warmup_steps: 5000
-  save_steps: 300
+  save_steps: 5
   num_train_epochs: 1
   logging_steps: 1
   add_special_tokens: false
@@ -51,7 +51,7 @@ training:
   segment_gradient_checkpointing: false
   learning_rate: 4e-3
   resume_from_checkpoint: true
-  # checkpoint_path: "/mnt/data2/galimzyanov/autocompressor/checkpoints/LLaMA-1.3B_sub3_seg2_sum50_lr0.004_bsz30_rand_accu_embed_only/checkpoint-300"
+  checkpoint_path: "/mnt/data2/galimzyanov/autocompressor/checkpoints/LLaMA-1.3B_sub3_seg2_sum50_embed_only_test/checkpoint-25"
   checkpointing: true  # If your training script supports checkpointing
   bf16: true
   train_embed_only: true
@@ -70,3 +70,4 @@ wandb:
   run_name: "LLaMA-1.3B"
   dir: "/mnt/data2/galimzyanov/autocompressor/checkpoints/"
   project: "autocompressors"
+  resume_run: true

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -11,7 +11,7 @@ defaults:
   logging_steps: 1
   add_special_tokens: false
   use_fast_tokenizer: false
-  num_gpus: 4
+  num_gpus: 2
   num_nodes: 1
   node: "localhost"
   accumulate_summary: true
@@ -52,7 +52,7 @@ training:
   randomize_substeps: true
   segment_gradient_checkpointing: false
   learning_rate: 4e-3
-  resume_from_checkpoint: false
+  resume_from_checkpoint: true
   # checkpoint_path: "/mnt/data2/galimzyanov/autocompressor/checkpoints/LLaMA-1.3B_sub3_seg2_sum50_lr0.004_bsz30_rand_accu_embed_only/checkpoint-300"
   checkpointing: true  # If your training script supports checkpointing
   bf16: true

--- a/load_model_from_ckpt.py
+++ b/load_model_from_ckpt.py
@@ -1,5 +1,8 @@
-from auto_compressor import LlamaAutoCompressorModel as AutoCompressorModel
+from auto_compressor import LlamaAutoCompressorModel
 from transformers import LlamaConfig
+from huggingface_hub.utils import HFValidationError
+from peft import PeftModel, get_peft_model, LoraConfig
+from pathlib import Path
 
 import os
 from omegaconf import OmegaConf
@@ -9,30 +12,81 @@ from utils import merge_ckpts
 # TODO check that llama is the model
 # if "llama" in (model_args.model_name_or_path or model_args.config_name).lower():
 
+def load_flat_config(config_path):
 
-def load_model_from_ckpt(checkpoint_path):
+    config = OmegaConf.load(config_path)
+    config = OmegaConf.to_container(config, resolve=True)
+    merged_config = {}
+    for d in list(config.values()):
+        merged_config.update(d)
 
-    base_folder = os.path.dirname(checkpoint_path)
-    temp_folder = os.path.join(base_folder, "checkpoint_merge_temp")
-    main_folder = os.path.join(base_folder, "base_model")
-    merge_ckpts(main_folder, checkpoint_path, temp_folder, config_filename="config_base_model.yaml")
-    config_path = os.path.join(main_folder, "config_base_model.yaml")
+    return config, merged_config
+
+def load_only_embed_model_from_ckpt(checkpoint_path: str):
+
+    checkpoint_path = Path(checkpoint_path)
+    base_folder = checkpoint_path.parent
+    main_folder = base_folder / "base_model"
+    temp_folder = base_folder / "checkpoint_merge_temp"
+
+    # TODO refactor merge_ckpts to use Path objects
+    merge_ckpts(str(main_folder), str(checkpoint_path), str(temp_folder), config_filename="config_base_model.yaml")
 
     config = LlamaConfig.from_pretrained(temp_folder)
-
-    model = AutoCompressorModel.from_pretrained(
+    model = LlamaAutoCompressorModel.from_pretrained(
         temp_folder,
         config=config,
         torch_dtype=config.torch_dtype,
     )
 
-    run_config = OmegaConf.load(config_path)
+    run_config = OmegaConf.load(main_folder / "config_base_model.yaml")
     run_config = OmegaConf.to_container(run_config, resolve=True)
 
     return model, run_config
 
-checkpoint_path = "/mnt/data2/galimzyanov/autocompressor/checkpoints/LLaMA-1.3B_sub3_seg2_sum50_embed_only_test/checkpoint-9900"
+def load_lora_model_from_ckpt(checkpoint_path: str):
+    checkpoint_path = Path(checkpoint_path)
+    base_folder = checkpoint_path.parent
+    main_folder = base_folder / "base_model"
+    config = LlamaConfig.from_pretrained(main_folder)
 
+    model = LlamaAutoCompressorModel.from_pretrained(main_folder, config=config, torch_dtype=config.torch_dtype)
+    run_config = OmegaConf.load(main_folder / "config_base_model.yaml")
+    run_config = OmegaConf.to_container(run_config, resolve=True)
+
+    try:
+        model = PeftModel.from_pretrained(model, checkpoint_path)
+    except HFValidationError as e:
+        raise e
+        print('Tried to load PEFT model but failed. Trying to load as a model+peft checkpoint')
+        with open(checkpoint_path / 'adapter_config.json') as fp:
+            peft_config_dict = json.load(fp)
+        print(json.dumps(peft_config_dict, indent=4))
+        peft_config = LoraConfig(peft_config_dict)
+        model = get_peft_model(model, peft_config)
+        model.load_state_dict(torch.load(checkpoint_path / 'pytorch_model.bin', map_location='cpu'))
+
+    model = model.merge_and_unload()
+
+    return model, run_config
+
+def load_model_from_ckpt(checkpoint_path: str):
+
+    checkpoint_path = Path(checkpoint_path)
+    base_folder = checkpoint_path.parent
+    main_folder = base_folder / "base_model"
+
+    config, merged_config = load_flat_config(main_folder / "config_base_model.yaml")
+
+    if merged_config["lora"]:
+        model, run_config = load_lora_model_from_ckpt(checkpoint_path)
+        print("Loaded LORA model")
+    if merged_config["train_embed_only"]:
+        model, run_config = load_only_embed_model_from_ckpt(checkpoint_path)
+        print("Loaded embeddings only model")
+
+    return model, run_config
+
+# checkpoint_path = "/mnt/data2/galimzyanov/autocompressor/checkpoints/LLaMA-1.3B_sub3_seg2_sum50_embed_only_test/checkpoint-9900"
+checkpoint_path = "/mnt/data2/galimzyanov/autocompressor/checkpoints/LLaMA-1.3B_sub3_seg2_sum50/checkpoint-2250"
 model, run_config = load_model_from_ckpt(checkpoint_path)
-
-print(1)

--- a/load_model_from_ckpt.py
+++ b/load_model_from_ckpt.py
@@ -89,6 +89,8 @@ def load_model_from_ckpt(checkpoint_path: str):
 
     return model, tokenizer, merged_config
 
-# checkpoint_path = "/mnt/data2/galimzyanov/autocompressor/checkpoints/LLaMA-1.3B_sub3_seg2_sum50_embed_only_test/checkpoint-9900"
-checkpoint_path = "/mnt/data2/galimzyanov/autocompressor/checkpoints/LLaMA-1.3B_sub3_seg2_sum50/checkpoint-2250"
-model, tokenizer, run_config = load_model_from_ckpt(checkpoint_path)
+
+if __name__ == '__main__':
+    # checkpoint_path = "/mnt/data2/galimzyanov/autocompressor/checkpoints/LLaMA-1.3B_sub3_seg2_sum50_embed_only_test/checkpoint-9900"
+    checkpoint_path = "/mnt/data2/galimzyanov/autocompressor/checkpoints/LLaMA-1.3B_sub3_seg2_sum50/checkpoint-2250"
+    model, tokenizer, run_config = load_model_from_ckpt(checkpoint_path)

--- a/load_model_from_ckpt.py
+++ b/load_model_from_ckpt.py
@@ -1,13 +1,14 @@
-from auto_compressor import LlamaAutoCompressorModel
-from transformers import LlamaConfig, AutoTokenizer
-from huggingface_hub.utils import HFValidationError
-from peft import PeftModel, get_peft_model, LoraConfig
 from pathlib import Path
 
-import os
+from huggingface_hub.utils import HFValidationError
 from omegaconf import OmegaConf
+from peft import PeftModel, get_peft_model, LoraConfig
+from tokenizers import Tokenizer
+from transformers import LlamaConfig, AutoTokenizer
 
+from auto_compressor import LlamaAutoCompressorModel
 from utils import merge_ckpts
+
 
 # TODO check that llama is the model
 # if "llama" in (model_args.model_name_or_path or model_args.config_name).lower():
@@ -73,7 +74,8 @@ def load_lora_model_from_ckpt(checkpoint_path: str, merged_config: dict):
     return model, tokenizer
 
 
-def load_model_from_ckpt(checkpoint_path: str):
+def load_model_from_ckpt(checkpoint_path: str | Path,
+                         ) -> tuple[LlamaAutoCompressorModel, Tokenizer, dict]:
 
     checkpoint_path = Path(checkpoint_path)
     base_folder = checkpoint_path.parent
@@ -96,5 +98,5 @@ def load_model_from_ckpt(checkpoint_path: str):
 
 if __name__ == '__main__':
     # checkpoint_path = "/mnt/data2/galimzyanov/autocompressor/checkpoints/LLaMA-1.3B_sub3_seg2_sum50_embed_only_test/checkpoint-9900"
-    checkpoint_path = "/mnt/data2/galimzyanov/autocompressor/checkpoints/LLaMA-1.3B_sub3_seg2_sum50/checkpoint-2250"
-    model, tokenizer, run_config = load_model_from_ckpt(checkpoint_path)
+    ckpt_path = "/mnt/data2/galimzyanov/autocompressor/checkpoints/LLaMA-1.3B_sub3_seg2_sum50/checkpoint-2250"
+    model, tokenizer, run_config = load_model_from_ckpt(ckpt_path)

--- a/load_model_from_ckpt.py
+++ b/load_model_from_ckpt.py
@@ -80,10 +80,13 @@ def load_model_from_ckpt(checkpoint_path: str):
 
     if merged_config["lora"]:
         model, run_config = load_lora_model_from_ckpt(checkpoint_path)
+        # TODO If you want, I can add function that saves the fused model as a checkpoint
         print("Loaded LORA model")
-    if merged_config["train_embed_only"]:
+    elif merged_config["train_embed_only"]:
         model, run_config = load_only_embed_model_from_ckpt(checkpoint_path)
         print("Loaded embeddings only model")
+    else:
+        print("Loading for this config state is not implemented yet")
 
     return model, run_config
 

--- a/load_model_from_ckpt.py
+++ b/load_model_from_ckpt.py
@@ -12,6 +12,7 @@ from utils import merge_ckpts
 # TODO check that llama is the model
 # if "llama" in (model_args.model_name_or_path or model_args.config_name).lower():
 
+
 def load_flat_config(config_path):
 
     config = OmegaConf.load(config_path)
@@ -21,6 +22,7 @@ def load_flat_config(config_path):
         merged_config.update(d)
 
     return config, merged_config
+
 
 def load_only_embed_model_from_ckpt(checkpoint_path: str, merged_config):
 
@@ -42,6 +44,7 @@ def load_only_embed_model_from_ckpt(checkpoint_path: str, merged_config):
     tokenizer = AutoTokenizer.from_pretrained(temp_folder, use_fast=merged_config["use_fast_tokenizer"])
 
     return model, tokenizer
+
 
 def load_lora_model_from_ckpt(checkpoint_path: str, merged_config: dict):
     checkpoint_path = Path(checkpoint_path)
@@ -68,6 +71,7 @@ def load_lora_model_from_ckpt(checkpoint_path: str, merged_config: dict):
     tokenizer = AutoTokenizer.from_pretrained(checkpoint_path, use_fast=merged_config["use_fast_tokenizer"])
 
     return model, tokenizer
+
 
 def load_model_from_ckpt(checkpoint_path: str):
 

--- a/load_model_from_ckpt.py
+++ b/load_model_from_ckpt.py
@@ -75,10 +75,13 @@ def load_lora_model_from_ckpt(checkpoint_path: str, merged_config: dict):
 
 
 def load_model_from_ckpt(checkpoint_path: str | Path,
+                         base_model_dir: str | Path | None = None
                          ) -> tuple[LlamaAutoCompressorModel, Tokenizer, dict]:
-
     checkpoint_path = Path(checkpoint_path)
-    base_folder = checkpoint_path.parent
+    if base_model_dir is None:
+        base_folder = checkpoint_path.parent
+    else:
+        base_folder = Path(base_model_dir)
     main_folder = base_folder / "base_model"
 
     config, merged_config = load_flat_config(main_folder / "config_base_model.yaml")

--- a/load_model_from_ckpt.py
+++ b/load_model_from_ckpt.py
@@ -1,0 +1,38 @@
+from auto_compressor import LlamaAutoCompressorModel as AutoCompressorModel
+from transformers import LlamaConfig
+
+import os
+from omegaconf import OmegaConf
+
+from utils import merge_ckpts
+
+# TODO check that llama is the model
+# if "llama" in (model_args.model_name_or_path or model_args.config_name).lower():
+
+
+def load_model_from_ckpt(checkpoint_path):
+
+    base_folder = os.path.dirname(checkpoint_path)
+    temp_folder = os.path.join(base_folder, "checkpoint_merge_temp")
+    main_folder = os.path.join(base_folder, "base_model")
+    merge_ckpts(main_folder, checkpoint_path, temp_folder, config_filename="config_base_model.yaml")
+    config_path = os.path.join(main_folder, "config_base_model.yaml")
+
+    config = LlamaConfig.from_pretrained(temp_folder)
+
+    model = AutoCompressorModel.from_pretrained(
+        temp_folder,
+        config=config,
+        torch_dtype=config.torch_dtype,
+    )
+
+    run_config = OmegaConf.load(config_path)
+    run_config = OmegaConf.to_container(run_config, resolve=True)
+
+    return model, run_config
+
+checkpoint_path = "/mnt/data2/galimzyanov/autocompressor/checkpoints/LLaMA-1.3B_sub3_seg2_sum50_embed_only_test/checkpoint-9900"
+
+model, run_config = load_model_from_ckpt(checkpoint_path)
+
+print(1)

--- a/train.py
+++ b/train.py
@@ -286,11 +286,12 @@ def main():
             load_check_merging(last_checkpoint, trainer)
         else:
             trainer._load_from_checkpoint(last_checkpoint)
+
+        process_indx = trainer.accelerator.state.process_index
+        print(f"--- Model loaded in process {process_indx} ---")
     else:
         logger.info("Using a model loaded from scratch!")
-    process_indx = trainer.accelerator.state.process_index
-    print(f"--- Model loaded in process {process_indx} ---")
-    return None
+
     # Training
     if training_args.do_train:
         save_base_model(config_path, trainer)
@@ -342,6 +343,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-    import time
-    time.sleep(5)
-

--- a/train.py
+++ b/train.py
@@ -256,6 +256,7 @@ def main():
         # scheduler = get_linear_schedule_with_warmup(optimizer, num_warmup_steps=training_args.warmup_steps, num_training_steps=num_training_steps)
     tokenizer.padding = True
 
+    # TODO add run_id
     MyEvalCallback = EvalCallback()
     trainer = SubstepTrainer(
         model=model,

--- a/train.py
+++ b/train.py
@@ -24,10 +24,6 @@ from config_parser import parse_config
 import shutil
 from pathlib import Path
 
-from accelerate import Accelerator
-
-accelerator = Accelerator()
-
 from data import load_raw_dataset, preprocess_datasets, load_preprocessed_datasets
 
 from fast_attention import patch_opt
@@ -84,8 +80,6 @@ def main():
     )
     logger.info(f"Training/evaluation parameters {training_args}")
 
-
-
     # load_datasets
     if not training_args.do_train:
         data_args.preprocessed_train_datasets = []
@@ -124,8 +118,6 @@ def main():
                 else:
                     eval_dataset[key] = lm_datasets[key]
 
-
-
     # Detecting last checkpoint.
     last_checkpoint = None
     if training_args.resume_from_checkpoint:
@@ -138,10 +130,8 @@ def main():
         else:
             print(f"Found checkpoint {last_checkpoint}. Using this checkpoint to resume training.")
 
-
     # Set seed before initializing model.
     set_seed(training_args.seed)
-
 
     tokenizer_kwargs = {
         "cache_dir": model_args.cache_dir,
@@ -266,10 +256,7 @@ def main():
         # scheduler = get_linear_schedule_with_warmup(optimizer, num_warmup_steps=training_args.warmup_steps, num_training_steps=num_training_steps)
     tokenizer.padding = True
 
-    training_args.eval_steps = 10
-
     MyEvalCallback = EvalCallback()
-
     trainer = SubstepTrainer(
         model=model,
         args=training_args,

--- a/utils.py
+++ b/utils.py
@@ -115,3 +115,8 @@ def load_check_merging(last_checkpoint: str, trainer):
         time.sleep(0.2)
     if trainer.state.is_local_process_zero and trainer.state.is_world_process_zero:
         shutil.rmtree(temp_folder)
+
+def wandb_setup(run_id):
+
+    os.environ["WANDB_RESUME"] = "must"
+    os.environ["WANDB_RUN_ID"] = run_id

--- a/utils.py
+++ b/utils.py
@@ -52,14 +52,33 @@ def calc_grad(model):
 
     return total_norm
 
+def check_proc_flags(folder: str, max_proc: int, prefix: str):
+    files = os.listdir(folder)
+    expected_files = [f'{prefix}_{i}' for i in range(max_proc)]
+    all_files_exist = all(file in files for file in expected_files)
+
+    return all_files_exist
+
+
+
 def load_check_merging(last_checkpoint: str, trainer):
+    process_indx = trainer.accelerator.state.process_index
+    max_proc = trainer.accelerator.num_processes
     base_folder = os.path.dirname(last_checkpoint)
-    flag_file = os.path.join(base_folder, "merging_done.flag")
+    temp_folder = os.path.join(base_folder, "checkpoint_merge_temp")
+    flag_file = os.path.join(temp_folder, ".merging_done_flag")
+    flag_prefix = ".flag_proc"
+    # TODO add node index too
+    flag_file_process = os.path.join(temp_folder, f"{flag_prefix}_{process_indx}")
     if trainer.state.is_local_process_zero and trainer.state.is_world_process_zero:
-        file_path_main = os.path.join(base_folder, "model.safetensors")
+        main_model_folder = os.path.join(base_folder, "base_model")
+        if os.path.exists(temp_folder):
+            shutil.rmtree(temp_folder)
+        shutil.copytree(last_checkpoint, temp_folder)
         file_path_part = os.path.join(last_checkpoint, "model.safetensors")
-        file_path_part_copy = os.path.join(last_checkpoint, "model_copy.safetensors_copy")
-        shutil.copy2(file_path_part, file_path_part_copy)
+        file_path_main = os.path.join(main_model_folder, "model.safetensors")
+        model_tensor_path = os.path.join(temp_folder, "model.safetensors")
+        os.remove(model_tensor_path)
         tensors = {}
         with safe_open(file_path_main, framework="pt", device=0) as f:
             for k in f.keys():
@@ -69,22 +88,26 @@ def load_check_merging(last_checkpoint: str, trainer):
             for k in f.keys():
                 tensors[k] = f.get_tensor(k)
 
-        save_file(tensors, file_path_part)
-
+        save_file(tensors, model_tensor_path)
         with open(flag_file, 'w') as f:
             pass
 
     else:
         exist_merge = os.path.exists(flag_file)
-        while exist_merge:
+        while not exist_merge:
             exist_merge = os.path.exists(flag_file)
-            time.sleep(0.5)
+            time.sleep(0.2)
 
-    trainer._load_from_checkpoint(last_checkpoint)
 
+    while not os.path.exists(temp_folder):
+        pass
+    trainer._load_from_checkpoint(temp_folder)
+    with open(flag_file_process, 'w') as f:
+        pass
+
+    wait = not check_proc_flags(temp_folder, max_proc, flag_prefix)
+    while wait:
+        wait = not check_proc_flags(temp_folder, max_proc, flag_prefix)
+        time.sleep(0.2)
     if trainer.state.is_local_process_zero and trainer.state.is_world_process_zero:
-        print("-------- setting back -------")
-        time.sleep(5)
-        shutil.copy2(file_path_part_copy, file_path_part)
-        os.remove(file_path_part_copy)
-        os.remove(flag_file)
+        shutil.rmtree(temp_folder)


### PR DESCRIPTION
Added script load_model_from_ckpt.py
Function `load_model_from_ckpt` takes the path to the checkpoint and returns AutoCompressorModel class with loaded checkpoint along with config on the run that was used to run this checkpoint.
Checkpoint parent folder should contain `base_model` folder with the state of the base model and the config of the run for this checkpoint.

The function reads from config_run whether the model was LORA or embeddings only. Then loads the model. Code for LLAMA loading I took from @mu-arkhipov function `merge_save_lora`

Load only embeddings function merges this base model with checkpoint state, creating `checkpoint_merge_temp` folder.
See for example files in `/mnt/data2/galimzyanov/autocompressor/checkpoints/LLaMA-1.3B_sub3_seg2_sum50_embed_only_test` folder

UPD. [e881b71] adds loading of the tokenizer